### PR TITLE
IPv4 optional on machine interface

### DIFF
--- a/config/L2_only_example.yaml
+++ b/config/L2_only_example.yaml
@@ -1,0 +1,30 @@
+# Basically a copy from exmaple.yaml, but without any IP addressing
+#
+# host1 --- router1 -- host3
+#
+
+switches: 2
+
+machines:
+  host21:
+    type: host
+    interfaces:
+      eth12:
+        mac: 00:00:00:00:00:11
+        bridge: 0
+  # This is a stupid router that should be configured by hand
+  router21:
+    type: router
+    interfaces:
+      eth12:
+        mac: 00:00:00:00:00:12
+        bridge: 0
+      eth23:
+        mac: 00:00:00:00:00:22
+        bridge: 1
+  host23:
+    type: host
+    interfaces:
+      eth23:
+        mac: 00:00:00:00:00:23
+        bridge: 1

--- a/vnet_manager/config/validate.py
+++ b/vnet_manager/config/validate.py
@@ -292,8 +292,9 @@ class ValidateConfig:
         interfaces = self.config["machines"][machine]["interfaces"]
         for int_name, int_vals in interfaces.items():
             if "ipv4" not in int_vals:
-                logger.error("ipv4 not found for interface {} on machine {}{}".format(int_name, machine, self.default_message))
-                self._all_ok = False
+                logger.debug(
+                    "No IPv4 found for interface {} on machine {}. That's okay, no IPv4 will be configured".format(int_name, machine)
+                )
             else:
                 # Validate the given IP
                 try:

--- a/vnet_manager/tests/config/test_validate.py
+++ b/vnet_manager/tests/config/test_validate.py
@@ -393,13 +393,10 @@ class TestValidateConfigValidateInterfaceConfig(VNetTestCase):
         self.validator.validate_interface_config("router100")
         self.assertTrue(self.validator.config_validation_successful)
 
-    def test_validate_interface_config_fails_when_ipv4_not_present(self):
+    def test_validate_interface_config_runs_ok_if_ipv4_not_present(self):
         del self.validator.config["machines"]["router100"]["interfaces"]["eth12"]["ipv4"]
         self.validator.validate_interface_config("router100")
-        self.assertFalse(self.validator.config_validation_successful)
-        self.logger.error.assert_called_once_with(
-            "ipv4 not found for interface eth12 on machine router100{}".format(self.validator.default_message)
-        )
+        self.assertTrue(self.validator.config_validation_successful)
 
     def test_validate_interface_config_fails_when_ipv4_not_valid(self):
         self.validator.config["machines"]["router100"]["interfaces"]["eth12"]["ipv4"] = "255.255.256.257"


### PR DESCRIPTION
It was basically already possible. Only the validator didn't allow it.