### PR TITLE
Skip defaults.yaml on list action

### DIFF
--- a/tools/yaml_syntax_validator.py
+++ b/tools/yaml_syntax_validator.py
@@ -7,7 +7,7 @@ from yamllint import linter
 
 from vnet_manager.conf import settings
 from vnet_manager.log import setup_console_logging
-from vnet_manager.utils.files import get_yaml_file_from_disk_path
+from vnet_manager.utils.files import get_yaml_files_from_disk_path
 
 
 logger = getLogger("tools.yaml_syntax_validator")
@@ -44,7 +44,7 @@ def main():
     parser = ArgumentParser(description="Verify (example) config files for valid YAML syntax")
     parser.parse_args()
 
-    yaml_files = get_yaml_file_from_disk_path(settings.CONFIG_FILE_DIR)
+    yaml_files = get_yaml_files_from_disk_path(settings.CONFIG_FILE_DIR)
     errors = check_yaml_file_syntax(yaml_files)
 
     logger.debug("#" * 80)

--- a/vnet_manager/actions/manager.py
+++ b/vnet_manager/actions/manager.py
@@ -8,7 +8,7 @@ from vnet_manager.config.config import get_config
 from vnet_manager.config.validate import ValidateConfig
 from vnet_manager.utils.version import show_version
 from vnet_manager.utils.user import request_confirmation, generate_bash_completion_script
-from vnet_manager.utils.files import write_file_to_disk, get_yaml_file_from_disk_path
+from vnet_manager.utils.files import write_file_to_disk, get_yaml_files_from_disk_path
 from vnet_manager.environment.lxc import ensure_vnet_lxc_environment, cleanup_vnet_lxc_environment
 from vnet_manager.operations.image import destroy_lxc_image
 from vnet_manager.operations.files import put_files_on_machine, generate_vnet_hosts_file, place_vnet_hosts_file_on_machines
@@ -176,7 +176,7 @@ class ActionManager:
             self.execute("show")
         elif isdir(self.config_path):
             # We exclude the default.yaml config file because it is not a valid user config
-            yaml_files = get_yaml_file_from_disk_path(self.config_path, excludes_files=settings.CONFIG_DEFAULTS_LOCATION)
+            yaml_files = get_yaml_files_from_disk_path(self.config_path, excludes_files=settings.CONFIG_DEFAULTS_LOCATION)
             for path in yaml_files:
                 self.config_path = path
                 if not self.parse_config():

--- a/vnet_manager/actions/manager.py
+++ b/vnet_manager/actions/manager.py
@@ -175,7 +175,8 @@ class ActionManager:
             # Execute the show action instead
             self.execute("show")
         elif isdir(self.config_path):
-            yaml_files = get_yaml_file_from_disk_path(self.config_path)
+            # We exclude the default.yaml config file because it is not a valid user config
+            yaml_files = get_yaml_file_from_disk_path(self.config_path, excludes_files=settings.CONFIG_DEFAULTS_LOCATION)
             for path in yaml_files:
                 self.config_path = path
                 if not self.parse_config():

--- a/vnet_manager/tests/actions/test_action_manager.py
+++ b/vnet_manager/tests/actions/test_action_manager.py
@@ -36,7 +36,7 @@ class TestActionManager(VNetTestCase):
         self.display_help_for_action = self.set_up_patch("vnet_manager.actions.manager.display_help_for_action")
         self.isfile = self.set_up_patch("vnet_manager.actions.manager.isfile")
         self.isdir = self.set_up_patch("vnet_manager.actions.manager.isdir")
-        self.get_yaml_file_from_disk_path = self.set_up_patch("vnet_manager.actions.manager.get_yaml_file_from_disk_path")
+        self.get_yaml_file_from_disk_path = self.set_up_patch("vnet_manager.actions.manager.get_yaml_files_from_disk_path")
         self.get_yaml_file_from_disk_path.return_value = ["file1"]
 
     def test_action_raises_not_implemented_error_if_unsupported_action(self):
@@ -103,7 +103,7 @@ class TestActionManager(VNetTestCase):
         self.isfile.return_value = False
         manager = ActionManager(config_path="blaap")
         manager.execute("list")
-        self.get_yaml_file_from_disk_path.assert_called_once_with("blaap")
+        self.get_yaml_file_from_disk_path.assert_called_once_with("blaap", excludes_files=settings.CONFIG_DEFAULTS_LOCATION)
 
     def test_action_manager_calls_show_status_with_return_values_of_get_yaml_files(self):
         self.get_yaml_file_from_disk_path.return_value = ["file1", "file2", "file3"]

--- a/vnet_manager/tests/utils/test_files.py
+++ b/vnet_manager/tests/utils/test_files.py
@@ -1,0 +1,34 @@
+from vnet_manager.tests import VNetTestCase
+from vnet_manager.utils.files import get_yaml_files_from_disk_path
+
+
+class TestGetYAMLFilesFromDiskPath(VNetTestCase):
+    def setUp(self) -> None:
+        self.walk = self.set_up_patch("vnet_manager.utils.files.walk")
+        self.walk.return_value = [
+            ("/foo", ("bar",), ("baz",)),
+            ("/foo/bar", (), ("spam.yaml", "eggs.yml", "hoi.txt")),
+        ]
+
+    def test_get_yaml_files_from_disk_path_calls_walk(self):
+        get_yaml_files_from_disk_path("path")
+        self.walk.assert_called_once_with("path")
+
+    def test_get_yaml_files_from_disk_path_returns_list(self):
+        self.assertIsInstance(get_yaml_files_from_disk_path("path"), list)
+
+    def test_get_yaml_files_from_disk_path_returns_yaml_files_in_path(self):
+        ret = get_yaml_files_from_disk_path("path")
+        self.assertEqual(ret, ["/foo/bar/spam.yaml", "/foo/bar/eggs.yml"])
+
+    def test_get_yaml_files_from_disk_path_excludes_filename(self):
+        ret = get_yaml_files_from_disk_path("path", excludes_files=["spam.yaml"])
+        self.assertEqual(ret, ["/foo/bar/eggs.yml"])
+
+    def test_get_yaml_files_from_disk_path_excludes_path(self):
+        ret = get_yaml_files_from_disk_path("path", excludes_files=["/foo/bar"])
+        self.assertEqual(ret, [])
+
+    def test_get_yaml_files_from_disk_path_excludes_path_and_filename(self):
+        ret = get_yaml_files_from_disk_path("path", excludes_files=["/foo/bar/spam.yaml"])
+        self.assertEqual(ret, ["/foo/bar/eggs.yml"])

--- a/vnet_manager/utils/files.py
+++ b/vnet_manager/utils/files.py
@@ -34,7 +34,7 @@ def write_file_to_disk(path, content):
         fh.write(content)
 
 
-def get_yaml_file_from_disk_path(path, excludes_files=None):
+def get_yaml_files_from_disk_path(path, excludes_files=None):
     """
     Returns a list of yaml files from a path (recursive search)
     :param path: str: The path to search in
@@ -45,8 +45,7 @@ def get_yaml_file_from_disk_path(path, excludes_files=None):
     def should_be_excluded(root_path, file):
         if excludes_files:
             return file in excludes_files or join(root_path, file) in excludes_files or root_path in excludes_files
-        else:
-            return False
+        return False
 
     yaml_files = []
     logger.debug("Retrieving yaml files from path: {}".format(path))

--- a/vnet_manager/utils/files.py
+++ b/vnet_manager/utils/files.py
@@ -34,16 +34,24 @@ def write_file_to_disk(path, content):
         fh.write(content)
 
 
-def get_yaml_file_from_disk_path(path):
+def get_yaml_file_from_disk_path(path, excludes_files=None):
     """
     Returns a list of yaml files from a path (recursive search)
     :param path: str: The path to search in
+    :param excludes_files: list: Of filenames or paths to exclude
     :return: list of paths: the found yaml files
     """
+
+    def should_be_excluded(root_path, file):
+        if excludes_files:
+            return file in excludes_files or join(root_path, file) in excludes_files or root_path in excludes_files
+        else:
+            return False
+
     yaml_files = []
     logger.debug("Retrieving yaml files from path: {}".format(path))
     for root, _, files in walk(path):
         for f in files:
-            if f.endswith("yaml") or f.endswith("yml"):
+            if (f.endswith("yaml") or f.endswith("yml")) and not should_be_excluded(root, f):
                 yaml_files.append(join(root, f))
     return yaml_files


### PR DESCRIPTION
So not to generate any weird errors when `vnet-manager list <path>` is called on a directory that contains the `defaults.yaml` config file.