### PR TITLE
Explicitly disable IP forwarding on hosts

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -14,7 +14,7 @@ switches: int  # Switches defines the number of vnet-bridges that should be crea
 
 machines: dict  # The machine dict defines that vnet machines that are part of this virtual network.
   host1: dict  # This dict defines a vnet machine.
-    type: str  # This define what type the machine will be, current options are host or router.
+    type: str  # This define what type the machine will be, see `Machine types`
     interfaces: dict  # This dict defines what virtual interfaces should be assigned to a machine.
       eth1: dict  # This dict defines a vnet interface, which is part of a vnet machine.
         ipv4: ipv4_address/cidr  # This IPv4 address will be assigned to the interface.
@@ -49,6 +49,11 @@ veths: dict  # Veths can be used to link two vnet bridges together (optional).
     stp: bool  # Weather to enable STP on the corresponding bridge interface (optional).
   vnet-vethN: ...
 ```
+
+### Machine types
+The machine type determines the specific configuration that will be placed on the machine. The following machine types are supported:
+- Host, simple endpoint, explicitly disables IP forwarding (set in /etc/sysctl.d/)
+- Router, IP forwarding enabled (set in /etc/sysctl.d/)
 
 ## Defaults config
 The defaults config defines some parameters that are used by VNet-manager for configuration. Most notably, the provider settings.

--- a/vnet_manager/operations/machine.py
+++ b/vnet_manager/operations/machine.py
@@ -306,14 +306,36 @@ def enable_type_specific_machine_configuration(config):
             getattr(modules[__name__], func)(machine_name)
 
 
-def configure_lxc_ip_forwarding(container_name):
+def enable_lxc_ip_forwarding(container_name):
+    """
+    Enables LXC IP forwarding for a machine
+    (Wrapper function for configure_lxc_ip_forwarding)
+    :param container_name: str The name of the container
+    """
+    configure_lxc_ip_forwarding(container_name, enable=True)
+
+
+def disable_lxc_ip_forwarding(container_name):
+    """
+    Disables LXC IP forwarding for a machine
+    (Wrapper function for configure_lxc_ip_forwarding)
+    :param container_name: str The name of the container
+    """
+    configure_lxc_ip_forwarding(container_name, enable=False)
+
+
+def configure_lxc_ip_forwarding(container_name, enable=True):
     """
     Configure a LXC machine to enable IP forwarding
     :param str container_name: The name of the container to enable IP forwarding on
+    :param bool enable: Whether to enable IP forwarding or disable it
     """
+    value = 1 if enable else 0
     logger.info("Enabling IP forwarding on LXC container {}".format(container_name))
-    write_file_to_lxc_container(container_name, "/etc/sysctl.d/20-net.ipv4.ip_forward.conf", "net.ipv4.ip_forward=1\n")
-    write_file_to_lxc_container(container_name, "/etc/sysctl.d/20-net.ipv6.conf.all.forwarding.conf", "net.ipv6.conf.all.forwarding=1\n")
+    write_file_to_lxc_container(container_name, "/etc/sysctl.d/20-net.ipv4.ip_forward.conf", "net.ipv4.ip_forward={}\n".format(value))
+    write_file_to_lxc_container(
+        container_name, "/etc/sysctl.d/20-net.ipv6.conf.all.forwarding.conf", "net.ipv6.conf.all.forwarding={}\n".format(value)
+    )
 
 
 def place_lxc_interface_configuration_on_container(config, container):

--- a/vnet_manager/settings/base.py
+++ b/vnet_manager/settings/base.py
@@ -80,8 +80,8 @@ MACHINE_TYPE_PROVIDER_MAPPING = {
 }
 MACHINE_TYPE_CONFIG_FUNCTION_MAPPING = {
     # For each machine type specify the type specific functions that should be called for it
-    "host": [],
-    "router": ["configure_{}_ip_forwarding".format(MACHINE_TYPE_PROVIDER_MAPPING["router"])],
+    "host": ["disable_{}_ip_forwarding".format(MACHINE_TYPE_PROVIDER_MAPPING["router"])],
+    "router": ["enable_{}_ip_forwarding".format(MACHINE_TYPE_PROVIDER_MAPPING["router"])],
 }
 VALID_STATUSES = ["start", "stop"]
 VNET_FORCE_ENV_VAR = "VNET_FORCE"

--- a/vnet_manager/settings/test.py
+++ b/vnet_manager/settings/test.py
@@ -30,10 +30,10 @@ CONFIG = {
             },
             "files": {"router101": "/etc/frr/"},
         },
-        "router102": {
-            "type": "router",
+        "host102": {
+            "type": "host",
             "interfaces": {"eth23": {"ipv4": "10.0.0.2/8", "ipv6": "fd00:23::2/64", "mac": "00:00:00:00:03:23", "bridge": 1}},
-            "files": {"router102": "/etc/frr/"},
+            "files": {"host102": "/etc/frr/"},
         },
     },
     "veths": {"vnet-veth1": {"bridge": "vnet-br1", "stp": True}, "vnet-veth0": {"peer": "vnet-veth1", "bridge": "vnet-br0", "stp": False},},
@@ -64,8 +64,8 @@ VALIDATED_CONFIG = {
             },
             "files": {"/root/vnet-manager/config/ripng/router101": "/etc/frr/"},
         },
-        "router102": {
-            "type": "router",
+        "host102": {
+            "type": "host",
             "interfaces": {"eth23": {"ipv4": "10.0.0.2/8", "ipv6": "fd00:23::2/64", "mac": "00:00:00:00:03:23", "bridge": 1}},
         },
     },

--- a/vnet_manager/tests/config/test_validate.py
+++ b/vnet_manager/tests/config/test_validate.py
@@ -298,7 +298,7 @@ class TestValidateConfigValidateMachineConfig(VNetTestCase):
     def test_validate_machine_config_succeeds_when_machine_files_not_present(self):
         del self.validator.config["machines"]["router100"]["files"]
         del self.validator.config["machines"]["router101"]["files"]
-        del self.validator.config["machines"]["router102"]["files"]
+        del self.validator.config["machines"]["host102"]["files"]
         self.validator.validate_machine_config()
         self.assertTrue(self.validator.config_validation_successful)
         self.assertFalse(self.validate_files.called)
@@ -319,7 +319,7 @@ class TestValidateConfigValidateMachineConfig(VNetTestCase):
     def test_validate_machine_config_fails_if_interfaces_is_not_a_dict(self):
         self.validator.config["machines"]["router100"]["interfaces"] = 42
         self.validator.config["machines"]["router101"]["interfaces"] = 42
-        self.validator.config["machines"]["router102"]["interfaces"] = 42
+        self.validator.config["machines"]["host102"]["interfaces"] = 42
         self.validator.validate_machine_config()
         self.assertFalse(self.validator.config_validation_successful)
         calls = [

--- a/vnet_manager/tests/operations/test_files.py
+++ b/vnet_manager/tests/operations/test_files.py
@@ -210,7 +210,7 @@ class TestGenerateVNetHostsFile(VNetTestCase):
         self.excepted_hosts_file = (
             settings.VNET_STATIC_HOSTS_FILE_PART
             + "192.168.0.2   router100\nfd00:12::2   router100\n192.168.0.1   router101\nfd00:12::1   router101\n10.0.0.1   "
-            "router101\nfd00:23::1   router101\n10.0.0.2   router102\nfd00:23::2   router102"
+            "router101\nfd00:23::1   router101\n10.0.0.2   host102\nfd00:23::2   host102"
         )
 
     @patch("builtins.open", new_callable=mock_open)

--- a/vnet_manager/tests/operations/test_interface.py
+++ b/vnet_manager/tests/operations/test_interface.py
@@ -45,7 +45,7 @@ class TestGetMachinesByVNetInterfaceName(VNetTestCase):
     def test_get_machines_by_vnet_interface_name_returns_the_correct_machines_per_interface(self):
         interface_mapping = {
             settings.VNET_BRIDGE_NAME + "0": ["router100", "router101"],
-            settings.VNET_BRIDGE_NAME + "1": ["router101", "router102"],
+            settings.VNET_BRIDGE_NAME + "1": ["router101", "host102"],
         }
         for interface in interface_mapping:
             self.assertEqual(get_machines_by_vnet_interface_name(settings.CONFIG, interface), interface_mapping[interface])

--- a/vnet_manager/tests/operations/test_machine.py
+++ b/vnet_manager/tests/operations/test_machine.py
@@ -32,7 +32,7 @@ class TestShowStatus(VNetTestCase):
         self.config = deepcopy(settings.CONFIG)
         # Only 1 machine for less output
         self.config["machines"].pop("router101", None)
-        self.config["machines"].pop("router102", None)
+        self.config["machines"].pop("host102", None)
 
     def test_show_status_call_get_lxc_machine_status(self):
         show_status(self.config)
@@ -258,13 +258,13 @@ class TestCreateLXCMachinesFromBaseImage(VNetTestCase):
         self.place_lxc_interface_configuration_on_container.assert_called_once_with(self.config, "router100")
 
     def test_create_lxc_machine_from_base_image_calls_create_functions_on_the_basis_of_the_number_of_containers(self):
-        create_lxc_machines_from_base_image(self.config, ["router100", "router101", "router102"])
+        create_lxc_machines_from_base_image(self.config, ["router100", "router101", "host102"])
         self.assertEqual(self.client.containers.create.call_count, 3)
         self.assertEqual(self.place_lxc_interface_configuration_on_container.call_count, 3)
 
     def test_create_lxc_machines_from_base_image_calls_request_confirmation_if_containers_already_created(self):
         self.check_if_lxc_machine_exists.return_value = True
-        create_lxc_machines_from_base_image(self.config, ["router100", "router102"])
+        create_lxc_machines_from_base_image(self.config, ["router100", "host102"])
         self.request_confirm.assert_called_once_with(
             message="Some containers already existed, the next operation will overwrite network, "
             "host and user config files on those containers"
@@ -279,7 +279,7 @@ class TestDestroyMachines(VNetTestCase):
     def test_destroy_machines_calls_request_confirmation(self):
         destroy_machines(settings.CONFIG)
         self.request_confirm.assert_called_once_with(
-            message="Requesting confirmation of deletion for the following machines: router100, router101, router102",
+            message="Requesting confirmation of deletion for the following machines: router100, router101, host102",
             prompt="This operation cannot be undone. Are you sure?! (yes/no) ",
         )
 
@@ -411,7 +411,9 @@ class TestEnableTypeSpecificMachineConfiguration(VNetTestCase):
 
     def test_enable_type_specific_machine_configuration_calls_configure_lxc_forwarding_for_each_machine(self):
         enable_type_specific_machine_configuration(settings.CONFIG)
-        self.configure_lxc_ip_forwarding.assert_has_calls([call("router100"), call("router101"), call("router102")])
+        self.configure_lxc_ip_forwarding.assert_has_calls(
+            [call("router100", enable=True), call("router101", enable=True), call("host102", enable=False)]
+        )
         self.assertEqual(self.configure_lxc_ip_forwarding.call_count, 3)
 
 


### PR DESCRIPTION
Apparently on LXC IPv4 forwarding is enabled by default.
Also, update the tests to include one host for testing.

This change has the downside that it could interfere with peoples custom config. 
If this is the case the user could manually delete `/etc/sysctl.d/20-net.ipv4.ip_forward.conf` and `/etc/sysctl.d/20-net.ipv6.conf.all.forwarding.conf`

Fixes: https://github.com/Erik-Lamers1/vnet-manager/issues/11