### PR TITLE
Shutdown base machine if DNS check fails

### DIFF
--- a/vnet_manager/environment/lxc.py
+++ b/vnet_manager/environment/lxc.py
@@ -97,6 +97,9 @@ def configure_lxc_base_machine(config):
         # No DNS connectivity (yet), try again
         sleep(2)
     if not dns:
+        # Shutdown base if DNS check fails
+        logger.debug("Stopping base machine")
+        machine.stop(wait=True)
         raise RuntimeError("Base machine started without working DNS, unable to continue")
 
     # Set the FRR routing source and key

--- a/vnet_manager/environment/lxc.py
+++ b/vnet_manager/environment/lxc.py
@@ -99,7 +99,7 @@ def configure_lxc_base_machine(config):
     if not dns:
         # Shutdown base if DNS check fails
         logger.debug("Stopping base machine")
-        machine.stop(wait=True)
+        machine.stop()
         raise RuntimeError("Base machine started without working DNS, unable to continue")
 
     # Set the FRR routing source and key

--- a/vnet_manager/tests/environment/test_lxc.py
+++ b/vnet_manager/tests/environment/test_lxc.py
@@ -122,6 +122,12 @@ class TestConfigureLXCBaseMachine(VNetTestCase):
             configure_lxc_base_machine(self.config)
         self.assertTrue(self.sleep.called)
 
+    def test_configure_lxc_base_machine_stops_base_if_no_dns_connectivity(self):
+        self.machine.execute.return_value = [1]
+        with self.assertRaises(RuntimeError):
+            configure_lxc_base_machine(self.config)
+        self.machine.stop.assert_called_once_with()
+
     def test_configure_lxc_base_machine_calls_correct_configure_cmds(self):
         calls = [
             call(shlex.split("bash -c 'curl -s https://deb.frrouting.org/frr/keys.asc | apt-key add'")),


### PR DESCRIPTION
When running `vnet-manager create`, configure_lxc_base_machine() performs a DNS check. If the check fails, an exception is raised but the base machine is not stopped.
This inconsistent state may cause issues e.g. running `vnet-manager destroy -b` after create will throw the message below even though the base image is still running:
```
[WARNING] Tried to destroy LXC image vnet-base, but it is already gone
```