### PR TITLE
Add avahi to guest packages

### DIFF
--- a/vnet_manager/settings/base.py
+++ b/vnet_manager/settings/base.py
@@ -69,6 +69,8 @@ PROVIDERS = {
             "frr",
             "frr-pythontools",
             "vlan",
+            "avahi-daemon",
+            "avahi-utils",
         ],
         "base_image": {  # Download info for the base image
             "os": "18.04",


### PR DESCRIPTION
Add avahi daemon and utils to guest packages. So people can test with mDNS.

As requested by @SyntheticOxygen 