### PR TITLE
Silence ws4py even more

### DIFF
--- a/vnet_manager/settings/base.py
+++ b/vnet_manager/settings/base.py
@@ -41,7 +41,7 @@ LOGGING = {
             "level": "INFO",
         },
         "ws4py": {
-            "level": "WARNING",
+            "level": "CRITICAL",
         },
         "pyroute2": {"level": "INFO"},
         "pyroute2.ndb": {"level": "WARNING"},


### PR DESCRIPTION
So it doesn't log the exceptions from PyLXD connections anymore on the console.