### PR TITLE
Silence PyLXD attribute warnings

### DIFF
--- a/vnet_manager/tests/test_vnet_manager.py
+++ b/vnet_manager/tests/test_vnet_manager.py
@@ -30,6 +30,10 @@ class TestVNetManagerMain(VNetTestCase):
         main(default_args + ["--yes"])
         self.assertEqual(environ[settings.VNET_FORCE_ENV_VAR], "true")
 
+    def test_main_sets_pylxd_warnings_env_variable(self):
+        main(default_args)
+        self.assertEqual(environ["PYLXD_WARNINGS"], "none")
+
     def test_main_calls_setup_console_logging(self):
         main(default_args)
         self.setup_console_logging.assert_called_once_with(verbosity=INFO)

--- a/vnet_manager/vnet_manager.py
+++ b/vnet_manager/vnet_manager.py
@@ -27,6 +27,8 @@ def main(args: Sequence = None) -> int:
     if not check_for_root_user():
         logger.critical("This program should only be run as root")
         return EX_NOPERM
+    # Silence the unknown attribute warnings from PyLXD
+    environ["PYLXD_WARNINGS"] = "none"
     # Let the action manager handle the rest
     manager = ActionManager(
         config_path=args.get("config"),


### PR DESCRIPTION
Right now PyLXD warns when settings attributes on unknown values, like;
```
/usr/local/lib/python3.10/dist-packages/pylxd/models/_model.py:146: UserWarning: Attempted to set unknown attribute "profiles" on instance of "Image"

```
We don't really care about these warnings, so now we silence them using the ENV var, as suggested in https://github.com/lxc/pylxd/blob/master/doc/source/usage.rst#userwarning-attempted-to-set-unknown-attribute-x-on-instance-of-y

Somewhat linked to https://github.com/Erik-Lamers1/vnet-manager/issues/50, in a effort to clean up the console even more.