### PR TITLE
Recognise and add tests for various types of invalid MAC addresses

### DIFF
--- a/vnet_manager/config/validate.py
+++ b/vnet_manager/config/validate.py
@@ -247,7 +247,7 @@ class ValidateConfig:
             elif isinstance(int_vals["mac"], int):
                 logger.error(
                     f"MAC {int_vals['mac']} for interface {int_name} on machine {machine} was parsed as a sexagesimal integer. "
-                    "Please wrap the MAC address between 'quotes'"
+                    "Please wrap the MAC address in 'quotes'"
                 )
                 self._all_ok = False
             # From: https://stackoverflow.com/a/7629690/8632038

--- a/vnet_manager/tests/config/test_validate.py
+++ b/vnet_manager/tests/config/test_validate.py
@@ -204,7 +204,7 @@ class TestValidateConfigValidateMachineConfig(VNetTestCase):
         self.validator.validate_interface_config("router100")
         self.assertFalse(self.validator.config_validation_successful)
         self.logger.error.assert_called_once_with(
-            f"MAC 33212743741 for interface eth12 on machine router100 was parsed as a sexagesimal integer. Please wrap the MAC address between 'quotes'"
+            f"MAC 33212743741 for interface eth12 on machine router100 was parsed as a sexagesimal integer. Please wrap the MAC address in 'quotes'"
         )
 
     def test_validate_interface_config_invalid_mac_address(self):


### PR DESCRIPTION
The YAML 1.1 specification allows PyYAML to parse certain MAC addresses as sexagesimal integers. Wrapping the MAC address between quotes is a valid workaround for that behavior, but because most users aren't aware of this YAML quirk, we should inform them explicitly.

Finally, I have added several tests for MAC address validation.

Fixes #62 